### PR TITLE
Add description to `/setting` commands and allow to enable/disable easter eggs

### DIFF
--- a/src/commands/About.ts
+++ b/src/commands/About.ts
@@ -48,8 +48,8 @@ export default class About {
             "**Founder**: Goos",
             "**Translator Lead**: ThatBOI",
             "**Developers**: Dimkauzh, Froxcey, Golem64, Koslz, MQuery, Nikkerudon, Spectrum, ThatBOI",
-            "**Designers**: ArtyH, Optix, Pjanda",
-            "**Translators**: Dimkauzh, flojo, Golem64, GraczNet, Nikkerudon, Optix, SaFire, TrulyBlue",
+            "**Designers**: ArtyH, ZakaHaceCosas, Pjanda",
+            "**Translators**: Dimkauzh, flojo, Golem64, GraczNet, Nikkerudon, ZakaHaceCosas, SaFire, TrulyBlue",
             "**Testers**: Blaze, fishy, Trynera",
             "And **YOU**, for using Sokora."
           ].join("\n")

--- a/src/commands/Settings.ts
+++ b/src/commands/Settings.ts
@@ -27,15 +27,15 @@ export default class Settings {
     settingsKeys.forEach(key => {
       const subcommand = new SlashCommandSubcommandBuilder()
         .setName(key)
-        .setDescription("This subcommand has no description.");
+        .setDescription(settingsDefinition[key].description);
 
-      Object.keys(settingsDefinition[key]).forEach(sub => {
-        switch (settingsDefinition[key][sub]["type"] as string) {
+      Object.keys(settingsDefinition[key].settings).forEach(sub => {
+        switch (settingsDefinition[key].settings[sub]["type"] as string) {
           case "BOOL":
             subcommand.addBooleanOption(option =>
               option
                 .setName(sub)
-                .setDescription(settingsDefinition[key][sub]["desc"])
+                .setDescription(settingsDefinition[key].settings[sub]["desc"])
                 .setRequired(false)
             );
             break;
@@ -43,7 +43,7 @@ export default class Settings {
             subcommand.addIntegerOption(option =>
               option
                 .setName(sub)
-                .setDescription(settingsDefinition[key][sub]["desc"])
+                .setDescription(settingsDefinition[key].settings[sub]["desc"])
                 .setRequired(false)
             );
             break;
@@ -51,7 +51,7 @@ export default class Settings {
             subcommand.addUserOption(option =>
               option
                 .setName(sub)
-                .setDescription(settingsDefinition[key][sub]["desc"])
+                .setDescription(settingsDefinition[key].settings[sub]["desc"])
                 .setRequired(false)
             );
             break;
@@ -63,7 +63,7 @@ export default class Settings {
             subcommand.addStringOption(option =>
               option
                 .setName(sub)
-                .setDescription(settingsDefinition[key][sub]["desc"])
+                .setDescription(settingsDefinition[key].settings[sub]["desc"])
                 .setRequired(false)
             );
             break;

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -15,7 +15,8 @@ export default (async function run(message) {
   const guild = message.guild!;
 
   // Easter egg handler
-  if (guild.id == "1079612082636472420") {
+  // i kept the old ID used here (if guild.id == "ID") in my .env file, just in case
+  if (getSetting(guild.id, "easter", "enabled") == true) {
     const eventsPath = join(process.cwd(), "src", "events", "easterEggs");
 
     for (const easterEggFile of readdirSync(eventsPath))

--- a/src/utils/database/settings.ts
+++ b/src/utils/database/settings.ts
@@ -13,102 +13,130 @@ const tableDefinition = {
 
 export const settingsDefinition: Record<
   string,
-  Record<string, { type: FieldData; desc: string; val?: any }>
+  {
+    description: string;
+    settings: Record<string, { type: FieldData; desc: string; val?: any }>;
+  }
 > = {
   levelling: {
-    enabled: { type: "BOOL", desc: "Enable/disable the levelling system.", val: true },
-    channel: {
-      type: "TEXT",
-      desc: "ID of the log channel for levelling-related stuff (i.e someone levelling up)."
-    },
-    block_channels: {
-      type: "TEXT",
-      desc: "ID(s) of the channels where messages aren't counted, comma separated."
-    },
-    // set_level: { type: "TEXT", desc: "Set the level of a user." },
-    // add_multiplier: {
-    //   type: "LIST",
-    //   desc: "Add an XP multiplier to the levelling system.",
-    //   val: {
-    //     multiplier: { type: "INTEGER", desc: "Set the XP multiplier for the role/channel." },
-    //     role_channel: { type: "TEXT", desc: "Role or channel. (choose)" },
-    //     id: { type: "TEXT", desc: "ID of the role/channel." }
-    //   }
-    // },
-    xp_gain: {
-      type: "INTEGER",
-      desc: "Set the amount of XP a user gains per message.",
-      val: 5
-    },
-    cooldown: {
-      type: "INTEGER",
-      desc: "Set the cooldown between messages that add XP.",
-      val: 2
-    },
-    difficulty: {
-      type: "INTEGER",
-      desc: "Set the difficulty (ex: 2 will make it 2x harder to level up).",
-      val: 1
+    description: "Customise the behaviour of the leveling system.",
+    settings: {
+      enabled: {
+        type: "BOOL",
+        desc: "Enable/disable the levelling system.",
+        val: true
+      },
+      channel: {
+        type: "TEXT",
+        desc: "ID of the log channel for levelling-related stuff (i.e someone levelling up)."
+      },
+      block_channels: {
+        type: "TEXT",
+        desc: "ID(s) of the channels where messages aren't counted, comma separated."
+      },
+      // set_level: { type: "TEXT", desc: "Set the level of a user." },
+      // add_multiplier: {
+      //   type: "LIST",
+      //   desc: "Add an XP multiplier to the levelling system.",
+      //   val: {
+      //     multiplier: { type: "INTEGER", desc: "Set the XP multiplier for the role/channel." },
+      //     role_channel: { type: "TEXT", desc: "Role or channel. (choose)" },
+      //     id: { type: "TEXT", desc: "ID of the role/channel." }
+      //   }
+      // },
+      xp_gain: {
+        type: "INTEGER",
+        desc: "Set the amount of XP a user gains per message.",
+        val: 5
+      },
+      cooldown: {
+        type: "INTEGER",
+        desc: "Set the cooldown between messages that add XP.",
+        val: 2
+      },
+      difficulty: {
+        type: "INTEGER",
+        desc: "Set the difficulty (ex: 2 will make it 2x harder to level up).",
+        val: 1
+      }
     }
   },
   moderation: {
-    channel: {
-      type: "TEXT",
-      desc: "ID of the log channel for moderation-related stuff (i.e a message being edited)."
-    },
-    log_messages: {
-      type: "BOOL",
-      desc: "Whether or not edited/deleted messages should be logged.",
-      val: true
+    description: "Tweak Sokora's moderation-related logs.",
+    settings: {
+      channel: {
+        type: "TEXT",
+        desc: "ID of the log channel for moderation-related stuff (i.e a message being edited)."
+      },
+      log_messages: {
+        type: "BOOL",
+        desc: "Whether or not edited/deleted messages should be logged.",
+        val: true
+      }
     }
   },
   news: {
-    channel_id: { type: "TEXT", desc: "ID of the channel where news messages are sent." },
-    role_id: {
-      type: "TEXT",
-      desc: "ID of the roles that should be pinged when a news message is sent."
-    },
-    edit_original_message: {
-      type: "BOOL",
-      desc: "Whether or not the original message should be edited when a news message is updated.",
-      val: true
+    description: "Configure news for this server.",
+    settings: {
+      channel_id: {
+        type: "TEXT",
+        desc: "ID of the channel where news messages are sent."
+      },
+      role_id: {
+        type: "TEXT",
+        desc: "ID of the roles that should be pinged when a news message is sent."
+      },
+      edit_original_message: {
+        type: "BOOL",
+        desc: "Whether or not the original message should be edited when a news message is updated.",
+        val: true
+      }
     }
   },
   serverboard: {
-    shown: {
-      type: "BOOL",
-      desc: "Whether or not the server should be shown on the serverboard.",
-      val: false
+    description: "Configure your server's appearance on the serverboard.",
+    settings: {
+      shown: {
+        type: "BOOL",
+        desc: "Whether or not the server should be shown on the serverboard.",
+        val: false
+      }
     }
   },
   welcome: {
-    join_text: {
-      type: "TEXT",
-      desc: "Text sent when a user joins. (name) - username, (count) - member count, (servername) - server name.",
-      val: "Welcome to (servername), (name)! Interestingly, you just helped us reach (count) members. Have a nice day!"
-    },
-    leave_text: {
-      type: "TEXT",
-      desc: "Text sent when a user leaves. (name) - username, (count) - member count, (servername) - server name.",
-      val: "(name) has left the server! 😥"
-    },
-    channel: { type: "TEXT", desc: "ID of the channel where welcome messages are sent." },
-    join_dm: {
-      type: "BOOL",
-      desc: "Whether or not the bot should send a custom DM message to the user upon joining.",
-      val: false
-    },
-    dm_text: {
-      type: "TEXT",
-      desc: "Text sent in the user's DM when they join the server. Same syntax as join_text.",
-      val: "Welcome to (servername), (name)! Interestingly, you just helped us reach (count) members. Have a nice day!"
+    description: "Tweak how Sokora welcomes your new users",
+    settings: {
+      join_text: {
+        type: "TEXT",
+        desc: "Text sent when a user joins. (name) - username, (count) - member count, (servername) - server name.",
+        val: "Welcome to (servername), (name)! Interestingly, you just helped us reach (count) members. Have a nice day!"
+      },
+      leave_text: {
+        type: "TEXT",
+        desc: "Text sent when a user leaves. (name) - username, (count) - member count, (servername) - server name.",
+        val: "(name) has left the server! 😥"
+      },
+      channel: { type: "TEXT", desc: "ID of the channel where welcome messages are sent." },
+      join_dm: {
+        type: "BOOL",
+        desc: "Whether or not the bot should send a custom DM message to the user upon joining.",
+        val: false
+      },
+      dm_text: {
+        type: "TEXT",
+        desc: "Text sent in the user's DM when they join the server. Same syntax as join_text.",
+        val: "Welcome to (servername), (name)! Interestingly, you just helped us reach (count) members. Have a nice day!"
+      }
     }
   },
   easter: {
-    enabled: {
+    description: "Enable or disable easter eggs",
+    settings: {
+      enabled: {
         type: "BOOL",
         desc: "Whether or not the bot should reply to certain messages with 'easter egg' messages.",
         val: true
+      }
     }
   }
 };
@@ -124,15 +152,18 @@ const insertQuery = database.query(
   "INSERT INTO settings (guildID, key, value) VALUES (?1, ?2, ?3);"
 );
 
-export function getSetting<K extends keyof typeof settingsDefinition>(
+export function getSetting<
+  K extends keyof typeof settingsDefinition,
+  S extends keyof (typeof settingsDefinition)[K]["settings"]
+>(
   guildID: string,
   key: K,
-  setting: string
-): TypeOfKey<K> | null {
+  setting: S
+): SqlType<(typeof settingsDefinition)[K]["settings"][S]["type"]> | null {
   let res = getQuery.all(JSON.stringify(guildID), key + "." + setting) as TypeOfDefinition<
     typeof tableDefinition
   >[];
-  const set = settingsDefinition[key][setting];
+  const set = settingsDefinition[key].settings[setting];
 
   if (!res.length) {
     if (set.type == "LIST") return null;
@@ -141,15 +172,15 @@ export function getSetting<K extends keyof typeof settingsDefinition>(
 
   switch (set.type) {
     case "TEXT":
-      return res[0].value as TypeOfKey<K>;
+      return res[0].value as SqlType<typeof set.type>;
     case "BOOL":
-      return (res[0].value === "1" ? true : false) as TypeOfKey<K>;
+      return (res[0].value === "1" ? true : false) as SqlType<typeof set.type>;
     case "INTEGER":
-      return parseInt(res[0].value) as TypeOfKey<K>;
+      return parseInt(res[0].value) as SqlType<typeof set.type>;
     case "LIST":
-      return kominator(res[0].value) as TypeOfKey<K>;
+      return kominator(res[0].value) as SqlType<typeof set.type>;
     default:
-      return "WIP" as TypeOfKey<K>;
+      return "WIP"; // as TypeOfKey<K>;
   }
 }
 
@@ -171,6 +202,6 @@ export function listPublicServers() {
 }
 
 // Utility type
-type TypeOfKey<T extends keyof typeof settingsDefinition> = SqlType<
-  (typeof settingsDefinition)[T][any]["type"]
+type TypeOfKey<K extends keyof typeof settingsDefinition, S extends string> = SqlType<
+  (typeof settingsDefinition)[K]["settings"][S]["type"]
 >;

--- a/src/utils/database/settings.ts
+++ b/src/utils/database/settings.ts
@@ -103,6 +103,13 @@ export const settingsDefinition: Record<
       desc: "Text sent in the user's DM when they join the server. Same syntax as join_text.",
       val: "Welcome to (servername), (name)! Interestingly, you just helped us reach (count) members. Have a nice day!"
     }
+  },
+  easter: {
+    enabled: {
+        type: "BOOL",
+        desc: "Whether or not the bot should reply to certain messages with 'easter egg' messages.",
+        val: true
+    }
   }
 };
 


### PR DESCRIPTION
This bot is looking fire so far. This PR does a few changes:

- Adds description to core settings commands (like `/settings leveling`). A few changes to TS types were made for that, but nothing should have broken.
- Allow everyone to enjoy easter eggs (which were restricted to a specific server), and allow them to opt out if desired via `/settings easter enabled` (TYPE: `BOOL`, VAL: `true`)
- Replace deprecated module (`optix()`) with current version (i updated my username in the About section, just that).
