### PR TITLE
[bug-fix] Fix duplicate command generation

### DIFF
--- a/src/handlers/commands.ts
+++ b/src/handlers/commands.ts
@@ -122,7 +122,7 @@ export class Commands {
 
   async registerCommandsForGuild(guild: Guild, ...disabledCommands: string[]) {
     await this.loadCommands(...disabledCommands);
-    await guild.commands.set(commands.map(command => command.data));
+    await guild.commands.set([...new Map(commands.map(command => [command.data.name, command])).values()].map(command => command.data));
   }
 
   async registerCommands(): Promise<any[]> {


### PR DESCRIPTION
This PR fixes an issue where commands would mysteriously be duplicated in the array, and the bot would thus die when added to a server with the new command handler.

PS: Discretion is advised. This one-liner will likely give you severe cases of PTSD due to the dirtiness of the fix, as reported by Worldometer as of 2024.