### PR TITLE
Show more info on serverEmbed + Add more (variables) + Add help command

### DIFF
--- a/src/commands/help/codes.ts
+++ b/src/commands/help/codes.ts
@@ -16,7 +16,7 @@ export const data = new SlashCommandSubcommandBuilder()
 
 export async function run(interaction: ChatInputCommandInteraction) {
   try {
-    // i know asserting types like this! is not a good practice but uhh yeah i have homework
+    // i know asserting types like this! is not a good practice but uhh yeah i have homework now, 'll validate this later
     const replacement: Replacements = [
       { text: "(name)", replacement: interaction.member!.user.username },
       { text: "(count)", replacement: interaction.guild!.memberCount },
@@ -25,14 +25,15 @@ export async function run(interaction: ChatInputCommandInteraction) {
       { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
     ];
 
-    const example = `Hi **(name)**! Thanks for joining *(servername)* at (currentdate), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
+    const example = `Welcome to (servername), **(name)**!`;
+    const exampleTwo = `Hi **(name)**! Thanks for joining *(servername)* at (currentdate), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
 
     const embed = new EmbedBuilder()
       .setTitle("Dynamic (codes)")
       .setDescription(
         "You can write the following codes in join and leave messages to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the join / leave message.",
       )
-      .setColor(genColor(150))
+      .setColor(genColor(200))
       .setFields([
         {
           name: "All codes",
@@ -49,12 +50,25 @@ export async function run(interaction: ChatInputCommandInteraction) {
           ].join("\n"),
         },
         {
-          name: "Example",
-          value: [`\`${example}\` will result in:`, "", `> ${replace(example, replacement)}`].join(
-            "\n",
-          ),
+          name: "Simple example",
+          value: [
+            `A simple example: \`${example}\` will result in:`,
+            "",
+            `> ${replace(example, replacement)}`,
+          ].join("\n"),
         },
-      ]);
+        {
+          name: "Full example",
+          value: [
+            `Adding everything, like: \`${exampleTwo}\` will result in:`,
+            "",
+            `> ${replace(exampleTwo, replacement)}`,
+          ].join("\n"),
+        },
+      ])
+      .setFooter({
+        text: "Sokora /help codes",
+      });
 
     await interaction.reply({ embeds: [embed] });
   } catch (error) {

--- a/src/commands/help/codes.ts
+++ b/src/commands/help/codes.ts
@@ -9,9 +9,7 @@ import { replaceCodes } from "../../utils/replace";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("codes")
-  .setDescription(
-    "Show a list of (codes) used to dynamically show data on join and leave messages",
-  );
+  .setDescription("Show a list of (codes) used to dynamically show data on certain messages");
 
 export async function run(interaction: ChatInputCommandInteraction) {
   try {
@@ -21,7 +19,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
     const embed = new EmbedBuilder()
       .setTitle("Dynamic (codes)")
       .setDescription(
-        "You can write the following codes in join and leave messages to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the join / leave message.",
+        "You can write the following codes in some places to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the specific message. Dynamic codes are currently supported for **join messages, leave messages, join DMs, and news.**",
       )
       .setColor(genColor(200))
       .setFields([

--- a/src/commands/help/codes.ts
+++ b/src/commands/help/codes.ts
@@ -16,7 +16,7 @@ export const data = new SlashCommandSubcommandBuilder()
 export async function run(interaction: ChatInputCommandInteraction) {
   try {
     const example = `Welcome to (servername), **(name)**!`;
-    const exampleTwo = `Hi **(name)**! Thanks for joining *(servername)* at (currentdate, simple), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
+    const exampleTwo = `Hi **(username)**! Thanks for joining *(servername)* at (currentdate, simple), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
 
     const embed = new EmbedBuilder()
       .setTitle("Dynamic (codes)")
@@ -34,9 +34,9 @@ export async function run(interaction: ChatInputCommandInteraction) {
           ].join("\n"),
         },
         {
-          name: "Full example",
+          name: "Another example",
           value: [
-            `Adding everything, like: \`${exampleTwo}\` will result in:`,
+            `Adding more stuff: \`${exampleTwo}\` will result in:`,
             "",
             `> ${await replaceCodes(exampleTwo, interaction.guild!, interaction.user)}`,
           ].join("\n"),
@@ -44,7 +44,8 @@ export async function run(interaction: ChatInputCommandInteraction) {
         {
           name: "All codes",
           value: [
-            `\`(name)\` - name of the user who joined`,
+            `\`(name)\` - display name of the user who joined`,
+            `\`(username)\` - username of the user who joined`,
             `\`(count)\` - member count`,
             `\`(servername)\` - name of this server`,
             `\`(serverowner)\` - ${
@@ -52,9 +53,9 @@ export async function run(interaction: ChatInputCommandInteraction) {
                 ? "your name!"
                 : "name of this server's owner"
             }`,
-            `\`(currentdate)\` - current date in the 'February 10, 2025' format`,
-            `\`(currentdate, simple)\` - current date in the '2/10/25' format`,
-            `\`(currentdate, detailed)\` - current date in the 'February 10, 2025, at 4:36 PM' format`,
+            `\`(currentdate)\` - current date in the 'July 10, 2025' format`,
+            `\`(currentdate, simple)\` - current date in the '7/10/25' format`,
+            `\`(currentdate, detailed)\` - current date in the 'July 10, 2025, at 1:11 PM' format`,
           ].join("\n"),
         },
       ])

--- a/src/commands/help/codes.ts
+++ b/src/commands/help/codes.ts
@@ -1,0 +1,67 @@
+import {
+  EmbedBuilder,
+  SlashCommandSubcommandBuilder,
+  type ChatInputCommandInteraction,
+} from "discord.js";
+import { errorEmbed } from "../../utils/embeds/errorEmbed";
+import { genColor } from "../../utils/colorGen";
+import { replace } from "../../utils/replace";
+import { Replacements } from "../../utils/types";
+
+export const data = new SlashCommandSubcommandBuilder()
+  .setName("codes")
+  .setDescription(
+    "Show a list of (codes) used to dynamically show data on join and leave messages",
+  );
+
+export async function run(interaction: ChatInputCommandInteraction) {
+  try {
+    // i know asserting types like this! is not a good practice but uhh yeah i have homework
+    const replacement: Replacements = [
+      { text: "(name)", replacement: interaction.member!.user.username },
+      { text: "(count)", replacement: interaction.guild!.memberCount },
+      { text: "(servername)", replacement: interaction.guild!.name },
+      { text: "(serverowner)", replacement: (await interaction.guild!.fetchOwner()).displayName },
+      { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
+    ];
+
+    const example = `Hi **(name)**! Thanks for joining *(servername)* at (currentdate), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
+
+    const embed = new EmbedBuilder()
+      .setTitle("Dynamic (codes)")
+      .setDescription(
+        "You can write the following codes in join and leave messages to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the join / leave message.",
+      )
+      .setColor(genColor(150))
+      .setFields([
+        {
+          name: "All codes",
+          value: [
+            `\`(name)\` - name of the user who joined`,
+            `\`(count)\` - member count`,
+            `\`(servername)\` - name of this server`,
+            `\`(serverowner)\` - ${
+              interaction.member?.user.id === interaction.guild?.ownerId
+                ? "your name!"
+                : "name of this server's owner"
+            }`,
+            `\`(currentdate)\` - current date, as a Discord timestamp`,
+          ].join("\n"),
+        },
+        {
+          name: "Example",
+          value: [`\`${example}\` will result in:`, "", `> ${replace(example, replacement)}`].join(
+            "\n",
+          ),
+        },
+      ]);
+
+    await interaction.reply({ embeds: [embed] });
+  } catch (error) {
+    return await errorEmbed(
+      interaction,
+      "Invalid function",
+      "Please provide a valid mathematical function. Examples: 'x^2', 'sin(x)', '2*x + 1'.",
+    );
+  }
+}

--- a/src/commands/help/codes.ts
+++ b/src/commands/help/codes.ts
@@ -5,8 +5,7 @@ import {
 } from "discord.js";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { genColor } from "../../utils/colorGen";
-import { replace } from "../../utils/replace";
-import { Replacements } from "../../utils/types";
+import { replaceCodes } from "../../utils/replace";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("codes")
@@ -16,17 +15,8 @@ export const data = new SlashCommandSubcommandBuilder()
 
 export async function run(interaction: ChatInputCommandInteraction) {
   try {
-    // i know asserting types like this! is not a good practice but uhh yeah i have homework now, 'll validate this later
-    const replacement: Replacements = [
-      { text: "(name)", replacement: interaction.member!.user.username },
-      { text: "(count)", replacement: interaction.guild!.memberCount },
-      { text: "(servername)", replacement: interaction.guild!.name },
-      { text: "(serverowner)", replacement: (await interaction.guild!.fetchOwner()).displayName },
-      { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
-    ];
-
     const example = `Welcome to (servername), **(name)**!`;
-    const exampleTwo = `Hi **(name)**! Thanks for joining *(servername)* at (currentdate), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
+    const exampleTwo = `Hi **(name)**! Thanks for joining *(servername)* at (currentdate, simple), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
 
     const embed = new EmbedBuilder()
       .setTitle("Dynamic (codes)")
@@ -35,6 +25,22 @@ export async function run(interaction: ChatInputCommandInteraction) {
       )
       .setColor(genColor(200))
       .setFields([
+        {
+          name: "Simple example",
+          value: [
+            `A simple example: \`${example}\` will result in:`,
+            "",
+            `> ${await replaceCodes(example, interaction.guild!, interaction.user)}`,
+          ].join("\n"),
+        },
+        {
+          name: "Full example",
+          value: [
+            `Adding everything, like: \`${exampleTwo}\` will result in:`,
+            "",
+            `> ${await replaceCodes(exampleTwo, interaction.guild!, interaction.user)}`,
+          ].join("\n"),
+        },
         {
           name: "All codes",
           value: [
@@ -46,23 +52,9 @@ export async function run(interaction: ChatInputCommandInteraction) {
                 ? "your name!"
                 : "name of this server's owner"
             }`,
-            `\`(currentdate)\` - current date, as a Discord timestamp`,
-          ].join("\n"),
-        },
-        {
-          name: "Simple example",
-          value: [
-            `A simple example: \`${example}\` will result in:`,
-            "",
-            `> ${replace(example, replacement)}`,
-          ].join("\n"),
-        },
-        {
-          name: "Full example",
-          value: [
-            `Adding everything, like: \`${exampleTwo}\` will result in:`,
-            "",
-            `> ${replace(exampleTwo, replacement)}`,
+            `\`(currentdate)\` - current date in the 'February 10, 2025' format`,
+            `\`(currentdate, simple)\` - current date in the '2/10/25' format`,
+            `\`(currentdate, detailed)\` - current date in the 'February 10, 2025, at 4:36 PM' format`,
           ].join("\n"),
         },
       ])

--- a/src/commands/help/variables.ts
+++ b/src/commands/help/variables.ts
@@ -3,7 +3,6 @@ import {
   SlashCommandSubcommandBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";
-import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { genColor } from "../../utils/colorGen";
 import { replaceVariables } from "../../utils/replace";
 
@@ -12,61 +11,53 @@ export const data = new SlashCommandSubcommandBuilder()
   .setDescription("Show a list of (variables) used to dynamically show data on certain messages");
 
 export async function run(interaction: ChatInputCommandInteraction) {
-  try {
-    const example = `Welcome to (servername), **(name)**!`;
-    const exampleTwo = `Hi **(username)**! Thanks for joining *(servername)* at (currentdate, simple), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
+  const example = `Welcome to (servername), **(name)**!`;
+  const exampleTwo = `Hi **(username)**! Thanks for joining *(servername)* at (currentdate, simple), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
 
-    const embed = new EmbedBuilder()
-      .setTitle("Dynamic (variables)")
-      .setDescription(
-        "You can write the following variables in some places to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the specific message. Dynamic variables are currently supported for **join messages, leave messages, join DMs, and news.**",
-      )
-      .setColor(genColor(200))
-      .setFields([
-        {
-          name: "Simple example",
-          value: [
-            `A simple example: \`${example}\` will result in:`,
-            "",
-            `> ${await replaceVariables(example, interaction.guild!, interaction.user)}`,
-          ].join("\n"),
-        },
-        {
-          name: "Another example",
-          value: [
-            `Adding more stuff: \`${exampleTwo}\` will result in:`,
-            "",
-            `> ${await replaceVariables(exampleTwo, interaction.guild!, interaction.user)}`,
-          ].join("\n"),
-        },
-        {
-          name: "All variables",
-          value: [
-            `\`(name)\` - display name of the user who joined`,
-            `\`(username)\` - username of the user who joined`,
-            `\`(count)\` - member count`,
-            `\`(servername)\` - name of this server`,
-            `\`(serverowner)\` - ${
-              interaction.member?.user.id === interaction.guild?.ownerId
-                ? "your name!"
-                : "name of this server's owner"
-            }`,
-            `\`(currentdate)\` - current date in the 'July 10, 2025' format`,
-            `\`(currentdate, simple)\` - current date in the '7/10/25' format`,
-            `\`(currentdate, detailed)\` - current date in the 'July 10, 2025, at 1:11 PM' format`,
-          ].join("\n"),
-        },
-      ])
-      .setFooter({
-        text: "Sokora /help variables",
-      });
+  const embed = new EmbedBuilder()
+    .setTitle("Dynamic (variables)")
+    .setDescription(
+      "You can write the following variables in some places to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the specific message. Dynamic variables are currently supported for **join messages, leave messages, join DMs, and news.**",
+    )
+    .setColor(genColor(200))
+    .setFields([
+      {
+        name: "Simple example",
+        value: [
+          `A simple example: \`${example}\` will result in:`,
+          "",
+          `> ${await replaceVariables(example, interaction.guild!, interaction.user)}`,
+        ].join("\n"),
+      },
+      {
+        name: "Another example",
+        value: [
+          `Adding more stuff: \`${exampleTwo}\` will result in:`,
+          "",
+          `> ${await replaceVariables(exampleTwo, interaction.guild!, interaction.user)}`,
+        ].join("\n"),
+      },
+      {
+        name: "All variables",
+        value: [
+          `\`(name)\` - display name of the user who joined`,
+          `\`(username)\` - username of the user who joined`,
+          `\`(count)\` - member count`,
+          `\`(servername)\` - name of this server`,
+          `\`(serverowner)\` - ${
+            interaction.member?.user.id === interaction.guild?.ownerId
+              ? "your name!"
+              : "name of this server's owner"
+          }`,
+          `\`(currentdate)\` - current date in the 'July 10, 2025' format`,
+          `\`(currentdate, simple)\` - current date in the '7/10/25' format`,
+          `\`(currentdate, detailed)\` - current date in the 'July 10, 2025, at 1:11 PM' format`,
+        ].join("\n"),
+      },
+    ])
+    .setFooter({
+      text: "Sokora /help variables",
+    });
 
-    await interaction.reply({ embeds: [embed] });
-  } catch (error) {
-    return await errorEmbed(
-      interaction,
-      "Invalid function",
-      "Please provide a valid mathematical function. Examples: 'x^2', 'sin(x)', '2*x + 1'.",
-    );
-  }
+  await interaction.reply({ embeds: [embed] });
 }

--- a/src/commands/help/variables.ts
+++ b/src/commands/help/variables.ts
@@ -5,11 +5,11 @@ import {
 } from "discord.js";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { genColor } from "../../utils/colorGen";
-import { replaceCodes } from "../../utils/replace";
+import { replaceVariables } from "../../utils/replace";
 
 export const data = new SlashCommandSubcommandBuilder()
-  .setName("codes")
-  .setDescription("Show a list of (codes) used to dynamically show data on certain messages");
+  .setName("variables")
+  .setDescription("Show a list of (variables) used to dynamically show data on certain messages");
 
 export async function run(interaction: ChatInputCommandInteraction) {
   try {
@@ -17,9 +17,9 @@ export async function run(interaction: ChatInputCommandInteraction) {
     const exampleTwo = `Hi **(username)**! Thanks for joining *(servername)* at (currentdate, simple), **(serverowner)** and the ***(count)*** members are happy to meet you!`;
 
     const embed = new EmbedBuilder()
-      .setTitle("Dynamic (codes)")
+      .setTitle("Dynamic (variables)")
       .setDescription(
-        "You can write the following codes in some places to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the specific message. Dynamic codes are currently supported for **join messages, leave messages, join DMs, and news.**",
+        "You can write the following variables in some places to dynamically show certain pieces of data. Data like 'current time' or 'member count' always refer to what that value is at the moment of sending the specific message. Dynamic variables are currently supported for **join messages, leave messages, join DMs, and news.**",
       )
       .setColor(genColor(200))
       .setFields([
@@ -28,7 +28,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
           value: [
             `A simple example: \`${example}\` will result in:`,
             "",
-            `> ${await replaceCodes(example, interaction.guild!, interaction.user)}`,
+            `> ${await replaceVariables(example, interaction.guild!, interaction.user)}`,
           ].join("\n"),
         },
         {
@@ -36,11 +36,11 @@ export async function run(interaction: ChatInputCommandInteraction) {
           value: [
             `Adding more stuff: \`${exampleTwo}\` will result in:`,
             "",
-            `> ${await replaceCodes(exampleTwo, interaction.guild!, interaction.user)}`,
+            `> ${await replaceVariables(exampleTwo, interaction.guild!, interaction.user)}`,
           ].join("\n"),
         },
         {
-          name: "All codes",
+          name: "All variables",
           value: [
             `\`(name)\` - display name of the user who joined`,
             `\`(username)\` - username of the user who joined`,
@@ -58,7 +58,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
         },
       ])
       .setFooter({
-        text: "Sokora /help codes",
+        text: "Sokora /help variables",
       });
 
     await interaction.reply({ embeds: [embed] });

--- a/src/commands/math/graph.ts
+++ b/src/commands/math/graph.ts
@@ -7,7 +7,7 @@ import {
 } from "discord.js";
 import * as math from "mathjs";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
-import { genColor, genRGBColor } from "../../utils/colorGen";
+import { genColor } from "../../utils/colorGen";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("graph")

--- a/src/commands/moderation/cases.ts
+++ b/src/commands/moderation/cases.ts
@@ -6,7 +6,7 @@ import {
 import { genColor } from "../../utils/colorGen";
 import { getModeration, listUserModeration } from "../../utils/database/moderation";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
-import { randomise } from "../../utils/randomise";
+import { randomize } from "../../utils/randomize";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("cases")
@@ -71,7 +71,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
           })
         : [
             {
-              name: `💨 • ${randomise(nothingMsg)}`,
+              name: `💨 • ${randomize(nothingMsg)}`,
               value: "*No actions have been taken on this user*",
             },
           ],

--- a/src/commands/news/add.ts
+++ b/src/commands/news/add.ts
@@ -11,7 +11,7 @@ import { genColor } from "../../utils/colorGen";
 import { addNews, listAllQuery } from "../../utils/database/news";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { sendChannelNews } from "../../utils/sendChannelNews";
-import { replaceCodes } from "../../utils/replace";
+import { replaceVariables } from "../../utils/replace";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("add")
@@ -55,13 +55,13 @@ export async function run(interaction: ChatInputCommandInteraction) {
   interaction.client.once("interactionCreate", async i => {
     if (!i.isModalSubmit()) return;
 
-    const title = await replaceCodes(
+    const title = await replaceVariables(
       i.fields.getTextInputValue("title"),
       interaction.guild!,
       interaction.user,
     );
 
-    const body = await replaceCodes(
+    const body = await replaceVariables(
       i.fields.getTextInputValue("body"),
       interaction.guild!,
       interaction.user,

--- a/src/commands/news/add.ts
+++ b/src/commands/news/add.ts
@@ -11,6 +11,7 @@ import { genColor } from "../../utils/colorGen";
 import { addNews, listAllQuery } from "../../utils/database/news";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { sendChannelNews } from "../../utils/sendChannelNews";
+import { replaceCodes } from "../../utils/replace";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("add")
@@ -54,16 +55,20 @@ export async function run(interaction: ChatInputCommandInteraction) {
   interaction.client.once("interactionCreate", async i => {
     if (!i.isModalSubmit()) return;
 
-    const id = (listAllQuery.all(guild.id).length + 1).toString();
-    addNews(
-      guild.id,
+    const title = await replaceCodes(
       i.fields.getTextInputValue("title"),
-      i.fields.getTextInputValue("body"),
-      i.user.displayName,
-      i.user.avatarURL()!,
-      null!,
-      id,
+      interaction.guild!,
+      interaction.user,
     );
+
+    const body = await replaceCodes(
+      i.fields.getTextInputValue("body"),
+      interaction.guild!,
+      interaction.user,
+    );
+
+    const id = (listAllQuery.all(guild.id).length + 1).toString();
+    addNews(guild.id, title, body, i.user.displayName, i.user.avatarURL()!, null!, id);
 
     await sendChannelNews(guild, id, interaction).catch(err => console.error(err));
     await i.reply({

--- a/src/events/easterEggs/amerikaYa.ts
+++ b/src/events/easterEggs/amerikaYa.ts
@@ -1,9 +1,9 @@
 import type { Message, TextChannel } from "discord.js";
-import { randomise } from "../../utils/randomise";
+import { randomize } from "../../utils/randomize";
 
 export async function run(message: Message) {
   if (message.content.trim().toLowerCase() != "amerika ya") return;
-  const response = randomise([
+  const response = randomize([
     "HALLO :D HALLO :D HALLO :D HALLO :D",
     "https://tenor.com/view/america-ya-gif-15374592095658975433",
   ]);

--- a/src/events/easterEggs/fan.ts
+++ b/src/events/easterEggs/fan.ts
@@ -1,9 +1,9 @@
 import type { Message, TextChannel } from "discord.js";
-import { randomise } from "../../utils/randomise";
+import { randomize } from "../../utils/randomize";
 
 export async function run(message: Message) {
   if (message.content.trim().toLowerCase() != "i'm a big fan") return;
-  const GIFs = randomise([
+  const GIFs = randomize([
     "https://tenor.com/bC37i.gif",
     "https://tenor.com/view/fan-gif-20757784",
     "https://tenor.com/view/below-deck-im-your-biggest-fan-biggest-fan-kate-kate-chastain-gif-15861715",

--- a/src/events/easterEggs/fire.ts
+++ b/src/events/easterEggs/fire.ts
@@ -1,9 +1,9 @@
 import type { Message, TextChannel } from "discord.js";
-import { randomise } from "../../utils/randomise";
+import { randomize } from "../../utils/randomize";
 
 export async function run(message: Message) {
   if (message.content.toLowerCase() != "fire in the hole") return;
-  const GIFs = randomise([
+  const GIFs = randomize([
     "https://cdn.discordapp.com/attachments/799130520846991370/1080439680199315487/cat-chomp-fireball.gif?ex=65e8485d&is=65d5d35d&hm=cef8b83df8120f1419082f184d835c6af679c9d02d69f97e335eafa82b33489e&",
     "https://tenor.com/view/dancing-gif-25178472",
     "https://tenor.com/view/fire-in-the-hole-gif-11283103876805231056",

--- a/src/events/easterEggs/whoPinged.ts
+++ b/src/events/easterEggs/whoPinged.ts
@@ -1,9 +1,9 @@
 import type { Message, TextChannel } from "discord.js";
-import { randomise } from "../../utils/randomise";
+import { randomize } from "../../utils/randomize";
 
 export async function run(message: Message) {
   if (message.content.trim().toLowerCase() != `<@${message.client.user.id}>`) return;
-  const GIFs = randomise([
+  const GIFs = randomize([
     "https://tenor.com/view/who-pinged-me-ping-discord-up-opening-door-gif-20065356",
     "https://tenor.com/view/discord-who-pinged-me-who-pinged-me-gif-25140226",
     "https://tenor.com/view/who-pinged-me-ping-discord-discord-ping-undertaker-gif-20399650",

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -2,7 +2,7 @@ import { EmbedBuilder, type TextChannel } from "discord.js";
 import { genColor } from "../utils/colorGen";
 import { getSetting } from "../utils/database/settings";
 import { imageColor } from "../utils/imageColor";
-import { replaceCodes } from "../utils/replace";
+import { replaceVariables } from "../utils/replace";
 import { Event } from "../utils/types";
 
 export default (async function run(member) {
@@ -23,7 +23,7 @@ export default (async function run(member) {
       ?.fetch()) as TextChannel;
 
     embed.setDescription(
-      await replaceCodes(
+      await replaceVariables(
         getSetting(guildID, "welcome", "join_text") as string,
         member.guild,
         member.user,
@@ -38,7 +38,7 @@ export default (async function run(member) {
   if (user.bot) return;
 
   embed.setDescription(
-    await replaceCodes(
+    await replaceVariables(
       getSetting(guildID, "welcome", "dm_text") as string,
       member.guild,
       member.user,

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -2,21 +2,14 @@ import { EmbedBuilder, type TextChannel } from "discord.js";
 import { genColor } from "../utils/colorGen";
 import { getSetting } from "../utils/database/settings";
 import { imageColor } from "../utils/imageColor";
-import { replace } from "../utils/replace";
-import { Event, Replacements } from "../utils/types";
+import { replaceCodes } from "../utils/replace";
+import { Event } from "../utils/types";
 
 export default (async function run(member) {
   const guildID = member.guild.id;
   const id = getSetting(guildID, "welcome", "channel") as string;
   const user = member.user;
   const avatar = member.displayAvatarURL();
-  const replacement: Replacements = [
-    { text: "(name)", replacement: user.displayName },
-    { text: "(count)", replacement: member.guild.memberCount },
-    { text: "(servername)", replacement: member.guild.name },
-    { text: "(serverowner)", replacement: (await member.guild.fetchOwner()).displayName },
-    { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
-  ];
 
   let embed = new EmbedBuilder()
     .setAuthor({ name: `•  ${user.displayName} has joined.`, iconURL: avatar })
@@ -30,7 +23,11 @@ export default (async function run(member) {
       ?.fetch()) as TextChannel;
 
     embed.setDescription(
-      replace(getSetting(guildID, "welcome", "join_text") as string, replacement),
+      await replaceCodes(
+        getSetting(guildID, "welcome", "join_text") as string,
+        member.guild,
+        member.user,
+      ),
     );
     await channel.send({ embeds: [embed] });
   }
@@ -40,7 +37,13 @@ export default (async function run(member) {
   if (!dmChannel) return;
   if (user.bot) return;
 
-  embed.setDescription(replace(getSetting(guildID, "welcome", "dm_text") as string, replacement));
+  embed.setDescription(
+    await replaceCodes(
+      getSetting(guildID, "welcome", "dm_text") as string,
+      member.guild,
+      member.user,
+    ),
+  );
   try {
     await dmChannel.send({ embeds: [embed] }).catch(() => null);
   } catch (e) {

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -3,17 +3,19 @@ import { genColor } from "../utils/colorGen";
 import { getSetting } from "../utils/database/settings";
 import { imageColor } from "../utils/imageColor";
 import { replace } from "../utils/replace";
-import { Event } from "../utils/types";
+import { Event, Replacements } from "../utils/types";
 
 export default (async function run(member) {
   const guildID = member.guild.id;
   const id = getSetting(guildID, "welcome", "channel") as string;
   const user = member.user;
   const avatar = member.displayAvatarURL();
-  const replacement = [
+  const replacement: Replacements = [
     { text: "(name)", replacement: user.displayName },
     { text: "(count)", replacement: member.guild.memberCount },
     { text: "(servername)", replacement: member.guild.name },
+    { text: "(serverowner)", replacement: (await member.guild.fetchOwner()).displayName },
+    { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
   ];
 
   let embed = new EmbedBuilder()

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -2,8 +2,8 @@ import { EmbedBuilder, type GuildMember, type TextChannel } from "discord.js";
 import { genColor } from "../utils/colorGen";
 import { getSetting } from "../utils/database/settings";
 import { imageColor } from "../utils/imageColor";
-import { replace } from "../utils/replace";
-import { Event, Replacements } from "../utils/types";
+import { replaceCodes } from "../utils/replace";
+import { Event } from "../utils/types";
 
 export default (async function run(member: GuildMember) {
   const guildID = member.guild.id;
@@ -11,13 +11,6 @@ export default (async function run(member: GuildMember) {
   if (!id) return;
   const user = member.user;
   const avatar = member.displayAvatarURL();
-  const replacement: Replacements = [
-    { text: "(name)", replacement: user.displayName },
-    { text: "(count)", replacement: member.guild.memberCount },
-    { text: "(servername)", replacement: member.guild.name },
-    { text: "(serverowner)", replacement: (await member.guild.fetchOwner()).displayName },
-    { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
-  ];
 
   const channel = (await member.guild.channels.cache
     .find(channel => channel.id == id)
@@ -25,7 +18,9 @@ export default (async function run(member: GuildMember) {
 
   const embed = new EmbedBuilder()
     .setAuthor({ name: `•  ${member.user.displayName} has left.`, iconURL: avatar })
-    .setDescription(replace(getSetting(guildID, "welcome", "join_text") as string, replacement))
+    .setDescription(
+      await replaceCodes(getSetting(guildID, "welcome", "join_text") as string, member.guild, user),
+    )
     .setFooter({ text: `User ID: ${member.id}` })
     .setThumbnail(avatar)
     .setColor(member.user.hexAccentColor ?? (await imageColor(undefined, avatar)) ?? genColor(200));

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -3,27 +3,29 @@ import { genColor } from "../utils/colorGen";
 import { getSetting } from "../utils/database/settings";
 import { imageColor } from "../utils/imageColor";
 import { replace } from "../utils/replace";
-import { Event } from "../utils/types";
+import { Event, Replacements } from "../utils/types";
 
 export default (async function run(member: GuildMember) {
   const guildID = member.guild.id;
   const id = getSetting(guildID, "welcome", "channel") as string;
   if (!id) return;
+  const user = member.user;
+  const avatar = member.displayAvatarURL();
+  const replacement: Replacements = [
+    { text: "(name)", replacement: user.displayName },
+    { text: "(count)", replacement: member.guild.memberCount },
+    { text: "(servername)", replacement: member.guild.name },
+    { text: "(serverowner)", replacement: (await member.guild.fetchOwner()).displayName },
+    { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
+  ];
 
   const channel = (await member.guild.channels.cache
     .find(channel => channel.id == id)
     ?.fetch()) as TextChannel;
 
-  const avatar = member.displayAvatarURL();
   const embed = new EmbedBuilder()
     .setAuthor({ name: `•  ${member.user.displayName} has left.`, iconURL: avatar })
-    .setDescription(
-      replace(getSetting(guildID, "welcome", "leave_text") as string, [
-        { text: "(name)", replacement: member.user.displayName },
-        { text: "(count)", replacement: member.guild.memberCount },
-        { text: "(servername)", replacement: member.guild.name },
-      ]),
-    )
+    .setDescription(replace(getSetting(guildID, "welcome", "join_text") as string, replacement))
     .setFooter({ text: `User ID: ${member.id}` })
     .setThumbnail(avatar)
     .setColor(member.user.hexAccentColor ?? (await imageColor(undefined, avatar)) ?? genColor(200));

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -2,7 +2,7 @@ import { EmbedBuilder, type GuildMember, type TextChannel } from "discord.js";
 import { genColor } from "../utils/colorGen";
 import { getSetting } from "../utils/database/settings";
 import { imageColor } from "../utils/imageColor";
-import { replaceCodes } from "../utils/replace";
+import { replaceVariables } from "../utils/replace";
 import { Event } from "../utils/types";
 
 export default (async function run(member: GuildMember) {
@@ -19,7 +19,11 @@ export default (async function run(member: GuildMember) {
   const embed = new EmbedBuilder()
     .setAuthor({ name: `•  ${member.user.displayName} has left.`, iconURL: avatar })
     .setDescription(
-      await replaceCodes(getSetting(guildID, "welcome", "join_text") as string, member.guild, user),
+      await replaceVariables(
+        getSetting(guildID, "welcome", "join_text") as string,
+        member.guild,
+        user,
+      ),
     )
     .setFooter({ text: `User ID: ${member.id}` })
     .setThumbnail(avatar)

--- a/src/utils/colorGen.ts
+++ b/src/utils/colorGen.ts
@@ -1,6 +1,6 @@
 /**
- * Randomises a color and outputs HEX.
- * @param hue Color to randomise.
+ * Randomizes a color and outputs HEX.
+ * @param hue Color to randomize.
  * @returns Color in HEX.
  */
 

--- a/src/utils/database/moderation.ts
+++ b/src/utils/database/moderation.ts
@@ -20,7 +20,6 @@ const database = getDatabase(definition);
 const addQuery = database.query(
   "INSERT INTO moderation (guild, user, type, moderator, reason, id, timestamp, expiresAt) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);",
 );
-const listGuildQuery = database.query("SELECT * FROM moderation WHERE guild = $1");
 const listUserQuery = database.query("SELECT * FROM moderation WHERE guild = $1 AND user = $2;");
 const listUserTypeQuery = database.query(
   "SELECT * FROM moderation WHERE guild = $1 AND user = $2 AND type = $3;",

--- a/src/utils/database/settings.ts
+++ b/src/utils/database/settings.ts
@@ -222,13 +222,13 @@ export const settingsDefinition: Record<
     settings: {
       join_text: {
         type: "TEXT",
-        desc: "Text sent when a user joins. You can use (codes) to add dynamic info, run /help codes for info.",
+        desc: "Text sent when a user joins. Use (variables) to add dynamic info, run /help variables for info.",
         val: "Welcome to (servername), (name)! Interestingly, you just helped us reach (count) members. Have a nice day!",
         emoji: "🍍",
       },
       leave_text: {
         type: "TEXT",
-        desc: "Text sent when a user leaves. You can use (codes) to add dynamic info, run /help codes for info.",
+        desc: "Text sent when a user leaves. Use (variables) to add dynamic info, run /help variables for info.",
         val: "(name) has left the server! 😥",
         emoji: "🍍",
       },

--- a/src/utils/database/settings.ts
+++ b/src/utils/database/settings.ts
@@ -222,13 +222,13 @@ export const settingsDefinition: Record<
     settings: {
       join_text: {
         type: "TEXT",
-        desc: "Text sent when a user joins. (name) - username, (count) - member count, (servername) - server name.",
+        desc: "Text sent when a user joins. You can use (codes) to add dynamic info, run /help codes for info.",
         val: "Welcome to (servername), (name)! Interestingly, you just helped us reach (count) members. Have a nice day!",
         emoji: "🍍",
       },
       leave_text: {
         type: "TEXT",
-        desc: "Text sent when a user leaves. (name) - username, (count) - member count, (servername) - server name.",
+        desc: "Text sent when a user leaves. You can use (codes) to add dynamic info, run /help codes for info.",
         val: "(name) has left the server! 😥",
         emoji: "🍍",
       },

--- a/src/utils/embeds/serverEmbed.ts
+++ b/src/utils/embeds/serverEmbed.ts
@@ -50,28 +50,20 @@ export async function serverEmbed(options: Options) {
   const TFA = guild.mfaLevel;
   const NSFW = guild.nsfwLevel;
 
-  const securityValues: (string | null)[] = [
+  const safetyValues: (string | null)[] = [
     `Setup: **${
       VL === 0 ? "None" : VL === 1 ? "Low" : VL === 2 ? "Mid" : VL === 3 ? "High" : "Very high"
     }** level`,
     `**${TFA === 1 ? "No" : "Has"}** 2FA`,
+    `NSFW: **${
+      NSFW === 0 ? "Default" : NSFW === 1 ? "Explicit" : NSFW === 2 ? "Safe" : "Age restricted"
+    }**`,
   ];
-
-  const NSFWstring =
-    NSFW === 0
-      ? "**Default**"
-      : NSFW === 1
-      ? "**Explicit**"
-      : NSFW === 2
-      ? "**Safe**"
-      : "**Age restricted**";
-
-  if (NSFWstring !== null) securityValues.push(`NSFW: ${NSFWstring}`);
 
   const embed = new EmbedBuilder()
     .setAuthor({
-      name: `${pages ? `#${page}  •  ` : icon ? "•  " : ""}${guild.name} ${
-        guild.verified ? "✅" : ""
+      name: `${pages ? `#${page}  •  ` : icon ? "•  " : ""}${guild.name}${
+        guild.verified ? " ✅" : ""
       }`,
       iconURL: icon,
     })
@@ -82,8 +74,8 @@ export async function serverEmbed(options: Options) {
         value: generalValues.join("\n"),
       },
       {
-        name: "🛡 • Security",
-        value: securityValues.join(" • "),
+        name: "🛡 • Safety",
+        value: safetyValues.join(" • "),
       },
     )
     .setFooter({ text: `${pages ? `Page ${page}/${pages}\n` : ""}Server ID: ${guild.id}` })

--- a/src/utils/embeds/serverEmbed.ts
+++ b/src/utils/embeds/serverEmbed.ts
@@ -1,10 +1,4 @@
-/**
- * Sends an embed containing information about the guild.
- * @param options Options of the embed.
- * @returns Embed that contains the guild info.
- */
-
-import { ChannelType, EmbedBuilder, Invite, type Guild } from "discord.js";
+import { EmbedBuilder, Invite, type Guild } from "discord.js";
 import { genColor } from "../colorGen";
 import { imageColor } from "../imageColor";
 import { pluralOrNot } from "../pluralOrNot";
@@ -20,6 +14,11 @@ type Options = {
   pages?: number;
 };
 
+/**
+ * Sends an embed containing information about the guild.
+ * @param options Options of the embed.
+ * @returns Embed that contains the guild info.
+ */
 export async function serverEmbed(options: Options) {
   const { page, pages, guild } = options;
   const { premiumTier: boostTier, premiumSubscriptionCount: boostCount } = guild;
@@ -47,13 +46,46 @@ export async function serverEmbed(options: Options) {
     `Created on **<t:${Math.round(guild.createdAt.valueOf() / 1000)}:D>**`,
   ];
 
+  const VL = guild.verificationLevel;
+  const TFA = guild.mfaLevel;
+  const NSFW = guild.nsfwLevel;
+
+  const securityValues: (string | null)[] = [
+    `Setup: **${
+      VL === 0 ? "None" : VL === 1 ? "Low" : VL === 2 ? "Mid" : VL === 3 ? "High" : "Very high"
+    }** level`,
+    `**${TFA === 1 ? "No" : "Has"}** 2FA`,
+  ];
+
+  const NSFWstring =
+    NSFW === 0
+      ? "**Default**"
+      : NSFW === 1
+      ? "**Explicit**"
+      : NSFW === 2
+      ? "**Safe**"
+      : "**Age restricted**";
+
+  if (NSFWstring !== null) securityValues.push(`NSFW: ${NSFWstring}`);
+
   const embed = new EmbedBuilder()
     .setAuthor({
-      name: `${pages ? `#${page}  •  ` : icon ? "•  " : ""}${guild.name}`,
+      name: `${pages ? `#${page}  •  ` : icon ? "•  " : ""}${guild.name} ${
+        guild.verified ? "✅" : ""
+      }`,
       iconURL: icon,
     })
-    .setDescription(guild.description ? guild.description : null)
-    .setFields({ name: "📃 • General", value: generalValues.join("\n") })
+    .setDescription(guild.description ? `> ${guild.description}` : null)
+    .setFields(
+      {
+        name: "📃 • General",
+        value: generalValues.join("\n"),
+      },
+      {
+        name: "🛡 • Security",
+        value: securityValues.join(" • "),
+      },
+    )
     .setFooter({ text: `${pages ? `Page ${page}/${pages}\n` : ""}Server ID: ${guild.id}` })
     .setThumbnail(icon)
     .setColor((await imageColor(icon)) ?? genColor(200));

--- a/src/utils/humanizeSettings.ts
+++ b/src/utils/humanizeSettings.ts
@@ -11,7 +11,9 @@ export function humanizeSettings(string: string) {
     .replaceAll("false", "Disabled")
     .replaceAll("(name)", "`(name)`")
     .replaceAll("(servername)", "`(servername)`")
-    .replaceAll("(count)", "`(count)`");
+    .replaceAll("(count)", "`(count)`")
+    .replaceAll("(serverowner)", "`(serverowner)`")
+    .replaceAll("(currentdate)", "`(currentdate)`");
 
   return humanized;
 }

--- a/src/utils/humanizeSettings.ts
+++ b/src/utils/humanizeSettings.ts
@@ -1,5 +1,5 @@
 /**
- * Outputs the given settings_string
+ * Outputs the given settings_string with formatting applied.
  * @param {string} string Settings string, either a key or a value.
  */
 export function humanizeSettings(string: string) {
@@ -13,7 +13,9 @@ export function humanizeSettings(string: string) {
     .replaceAll("(servername)", "`(servername)`")
     .replaceAll("(count)", "`(count)`")
     .replaceAll("(serverowner)", "`(serverowner)`")
-    .replaceAll("(currentdate)", "`(currentdate)`");
+    .replaceAll("(currentdate)", "`(currentdate)`")
+    .replaceAll("(currentdate, simple)", "`(currentdate, simple))`")
+    .replaceAll("(currentdate, detailed)", "`(currentdate, detailed)`");
 
   return humanized;
 }

--- a/src/utils/randomise.ts
+++ b/src/utils/randomise.ts
@@ -1,9 +1,0 @@
-/**
- * Randomises array values.
- * @param array Array to randomise.
- * @returns Randomised value from within the array.
- */
-
-export function randomise(array: any[]) {
-  return array[Math.floor(Math.random() * array.length)];
-}

--- a/src/utils/randomize.ts
+++ b/src/utils/randomize.ts
@@ -1,0 +1,9 @@
+/**
+ * Randomizes array values.
+ * @param array Array to randomize.
+ * @returns Randomized value from within the array.
+ */
+
+export function randomize(array: any[]) {
+  return array[Math.floor(Math.random() * array.length)];
+}

--- a/src/utils/replace.ts
+++ b/src/utils/replace.ts
@@ -1,10 +1,12 @@
-import { randomise } from "./randomise";
+import { Guild, User } from "discord.js";
+import { randomize } from "./randomize";
+import { Replacements } from "./types";
 
 let emojis = ["💖", "💝", "💓", "💗", "💘", "💟", "💕", "💞"];
 if (Math.round(Math.random() * 100) <= 5) emojis = ["⌨️", "💻", "🖥️"];
 
 export const replacements = [
-  { text: "(madeWith)", replacement: `Made with ${randomise(emojis)} by the Sokora team` },
+  { text: "(madeWith)", replacement: `Made with ${randomize(emojis)} by the Sokora team` },
 ];
 
 export function replace(text: string, replaceText?: { text: string; replacement: any }[]) {
@@ -12,4 +14,28 @@ export function replace(text: string, replaceText?: { text: string; replacement:
     if (text?.includes(mention.text)) text = text.replaceAll(mention.text, mention.replacement);
 
   return text;
+}
+
+
+/**
+ * Takes custom `(codes)` and replaces them with the string they represent.
+ *
+ * @async
+ * @param {string} text String to have its codes replaced.
+ * @param {Guild} guild Guild.
+ * @param {User} user User.
+ * @returns {Promise<string>} String with values replaced. The function is async because it depends on `fetchOwner()`.
+ */
+export async function replaceCodes(text: string, guild: Guild, user: User): Promise<string> {
+  const replacementCodes: Replacements = [
+    { text: "(name)", replacement: user.username },
+    { text: "(count)", replacement: guild.memberCount },
+    { text: "(servername)", replacement: guild.name },
+    { text: "(serverowner)", replacement: (await guild.fetchOwner()).displayName },
+    { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}:D>` },
+    { text: "(currentdate, simple)", replacement: `<t:${Math.floor(Date.now() / 1000)}:d>` },
+    { text: "(currentdate, detailed)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
+  ];
+
+  return replace(text, replacementCodes);
 }

--- a/src/utils/replace.ts
+++ b/src/utils/replace.ts
@@ -28,7 +28,8 @@ export function replace(text: string, replaceText?: { text: string; replacement:
  */
 export async function replaceCodes(text: string, guild: Guild, user: User): Promise<string> {
   const replacementCodes: Replacements = [
-    { text: "(name)", replacement: user.username },
+    { text: "(name)", replacement: user.displayName },
+    { text: "(username)", replacement: user.username },
     { text: "(count)", replacement: guild.memberCount },
     { text: "(servername)", replacement: guild.name },
     { text: "(serverowner)", replacement: (await guild.fetchOwner()).displayName },

--- a/src/utils/replace.ts
+++ b/src/utils/replace.ts
@@ -16,18 +16,17 @@ export function replace(text: string, replaceText?: { text: string; replacement:
   return text;
 }
 
-
 /**
- * Takes custom `(codes)` and replaces them with the string they represent.
+ * Takes custom `(variables)` and replaces them with the string they represent.
  *
  * @async
- * @param {string} text String to have its codes replaced.
+ * @param {string} text String to have its variables replaced.
  * @param {Guild} guild Guild.
  * @param {User} user User.
  * @returns {Promise<string>} String with values replaced. The function is async because it depends on `fetchOwner()`.
  */
-export async function replaceCodes(text: string, guild: Guild, user: User): Promise<string> {
-  const replacementCodes: Replacements = [
+export async function replaceVariables(text: string, guild: Guild, user: User): Promise<string> {
+  const replacementVariables: Replacements = [
     { text: "(name)", replacement: user.displayName },
     { text: "(username)", replacement: user.username },
     { text: "(count)", replacement: guild.memberCount },
@@ -38,5 +37,5 @@ export async function replaceCodes(text: string, guild: Guild, user: User): Prom
     { text: "(currentdate, detailed)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
   ];
 
-  return replace(text, replacementCodes);
+  return replace(text, replacementVariables);
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,12 @@
 import { ClientEvents } from "discord.js";
 
 export type Event<K extends keyof ClientEvents> = (...args: ClientEvents[K]) => any;
+
+export type ReplaceableStrings =
+  | "(name)"
+  | "(count)"
+  | "(servername)"
+  | "(serverowner)"
+  | "(currentdate)";
+
+export type Replacements = { text: ReplaceableStrings; replacement: string | number }[];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -7,6 +7,8 @@ export type ReplaceableStrings =
   | "(count)"
   | "(servername)"
   | "(serverowner)"
-  | "(currentdate)";
+  | "(currentdate)"
+  | "(currentdate, simple)"
+  | "(currentdate, detailed)";
 
 export type Replacements = { text: ReplaceableStrings; replacement: string | number }[];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,6 +4,7 @@ export type Event<K extends keyof ClientEvents> = (...args: ClientEvents[K]) => 
 
 export type ReplaceableStrings =
   | "(name)"
+  | "(username)"
   | "(count)"
   | "(servername)"
   | "(serverowner)"


### PR DESCRIPTION
- Show basic security info in the server embed without loosing compactness. Also, while I don't know what a verified server is, if a server is verified, a verified checkmark will appear next to its name, showcasing that it is, indeed, verified.
- Add `(username)`, `(serverowner)` and `(currentdate)`/`(currentdate, simple)`/`(currentdate, detailed)` variables.
  - (Goos decision) Make "variables" (or "dynamic variables" as I call them) the official name of these thingies.
- Add `/help variables` - this was made as a necessity, because Discord limits to a 100 chars the command description so we couldn't describe all variables in there. It would make sense to add more help commands in the future (I can take care of that if needed).
- Add a `replaceVariables(text: string, guild: Guild, user: User)` async function to replace variables anywhere you want them to be implemented.
- Removed a few unused declarations / imports.
- Renamed `randomise.ts` to `randomize.ts` (so it uses US english).