### PR TITLE
Fix non-public-anymore servers staying in the list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 data.db
 .idea
 .vscode/
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <div align="center">
-  <p>
-    <img src="static/banner.png" />
-  </p>
-  <p>
-    <a href="https://discord.gg/c6C25P4BuY"><img src="https://img.shields.io/discord/903852579837059113?color=5865F2&logo=discord&logoColor=white" /></a>
-    <a href="https://ptb.discord.com/api/oauth2/authorize?client_id=873918300726394960&permissions=8&scope=bot%20applications.commands"><img src="https://img.shields.io/badge/bot-Invite%20the%20bot%20here!-blue" /></a>
-  </p>
+
+![Sokora's banner](static/banner.png)
+
+[<img src="https://img.shields.io/discord/903852579837059113?color=5865F2&logo=discord&logoColor=white" />](https://discord.gg/c6C25P4BuY)
+[<img src="https://img.shields.io/badge/bot-Invite%20the%20bot%20here!-blue" />](https://ptb.discord.com/api/oauth2/authorize?client_id=873918300726394960&permissions=8&scope=bot%20applications.commands)
+
 </div>
 
 # About

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Sokora is a multipurpose Discord bot that lets you manage your servers easily.
 
 # Contributing
 
-While we're developing the bot, you can [help us](CONTRIBUTING.MD) if you find any bugs.
+While we're developing the bot, you can [help us](CONTRIBUTING.md) if you find any bugs.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "sokora",
       "dependencies": {
         "canvas": "^3.1.0",
-        "discord.js": "^14.17.3",
+        "discord.js": "^14.18.0",
         "mathjs": "^14.2.1",
         "ms": "^2.1.3",
         "node-vibrant": "^3.2.1-alpha.1",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -35,6 +35,3 @@ client.on("ready", async () => {
 });
 
 client.login(process.env.TOKEN);
-
-/** UserID of Sokora */
-export const SOKORA_ID = "873918300726394960"

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -35,3 +35,6 @@ client.on("ready", async () => {
 });
 
 client.login(process.env.TOKEN);
+
+/** UserID of Sokora */
+export const SOKORA_ID = "873918300726394960"

--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -11,6 +11,7 @@ import { genColor } from "../utils/colorGen";
 import { imageColor } from "../utils/imageColor";
 import { pluralOrNot } from "../utils/pluralOrNot";
 import { replace } from "../utils/replace";
+import { SOKORA_ID } from "../bot";
 
 export const data = new SlashCommandBuilder()
   .setName("about")
@@ -55,7 +56,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
   const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
       .setLabel("• Vote")
-      .setURL("https://top.gg/bot/873918300726394960/vote")
+      .setURL(`https://top.gg/bot/${SOKORA_ID}/vote`)
       .setEmoji("🗳️")
       .setStyle(ButtonStyle.Link),
     new ButtonBuilder()

--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -11,7 +11,6 @@ import { genColor } from "../utils/colorGen";
 import { imageColor } from "../utils/imageColor";
 import { pluralOrNot } from "../utils/pluralOrNot";
 import { replace } from "../utils/replace";
-import { SOKORA_ID } from "../bot";
 
 export const data = new SlashCommandBuilder()
   .setName("about")
@@ -56,7 +55,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
   const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
       .setLabel("• Vote")
-      .setURL(`https://top.gg/bot/${SOKORA_ID}/vote`)
+      .setURL("https://top.gg/bot/873918300726394960/vote")
       .setEmoji("🗳️")
       .setStyle(ButtonStyle.Link),
     new ButtonBuilder()

--- a/src/commands/games/rps.ts
+++ b/src/commands/games/rps.ts
@@ -23,10 +23,10 @@ export const data = new SlashCommandSubcommandBuilder()
   .setName("rps")
   .setDescription("Play Rock Paper Scissors")
   .addUserOption(option =>
-    option.setName("opponent").setDescription("The user to play against (optional)"),
+    option.setName("opponent").setDescription("The user to play against (optional)."),
   );
 
-function getWinner(choice1: RPSChoice, choice2: RPSChoice): number {
+function getWinner(choice1: RPSChoice, choice2: RPSChoice): 0 | 1 | 2 {
   if (choice1 === choice2) return 0;
   if (
     (choice1 === "rock" && choice2 === "scissors") ||
@@ -39,6 +39,24 @@ function getWinner(choice1: RPSChoice, choice2: RPSChoice): number {
 
 export async function run(interaction: ChatInputCommandInteraction) {
   const opponent = interaction.options.getUser("opponent");
+  const optionsRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    ...rpsChoices.map((choice: RPSChoice) =>
+      new ButtonBuilder()
+        .setCustomId(`rps_${choice}`)
+        .setEmoji(rpsEmojis[choice])
+        .setStyle(ButtonStyle.Primary),
+    ),
+  );
+  const baseEmbed = new EmbedBuilder()
+    .setTitle("Rock Paper Scissors")
+    .setDescription(
+      opponent
+        ? `${interaction.user} has challenged ${opponent} to a game!\n` +
+            `Both players, make your choice!`
+        : `Choose your weapon!`,
+    )
+    .setColor(genColor(110));
+
   if (opponent) {
     if (opponent.bot)
       return await errorEmbed(
@@ -54,26 +72,9 @@ export async function run(interaction: ChatInputCommandInteraction) {
     if (opponent.id == interaction.user.id)
       return await errorEmbed(interaction, "Invalid opponent", "You cannot play against yourself!");
 
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      ...rpsChoices.map((choice: RPSChoice) =>
-        new ButtonBuilder()
-          .setCustomId(`rps_${choice}`)
-          .setEmoji(rpsEmojis[choice])
-          .setStyle(ButtonStyle.Primary),
-      ),
-    );
-
-    const embed = new EmbedBuilder()
-      .setTitle("Rock Paper Scissors")
-      .setDescription(
-        `${interaction.user} has challenged ${opponent} to a game!\n` +
-          `Both players, make your choice!`,
-      )
-      .setColor(genColor(120));
-
     const reply = await interaction.reply({
-      embeds: [embed],
-      components: [row],
+      embeds: [baseEmbed],
+      components: [optionsRow],
     });
 
     const playerChoices = new Map<string, RPSChoice>();
@@ -125,23 +126,9 @@ export async function run(interaction: ChatInputCommandInteraction) {
     return;
   }
 
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    ...rpsChoices.map((choice: RPSChoice) =>
-      new ButtonBuilder()
-        .setCustomId(`rps_${choice}`)
-        .setEmoji(rpsEmojis[choice])
-        .setStyle(ButtonStyle.Primary),
-    ),
-  );
-
-  const embed = new EmbedBuilder()
-    .setTitle("Rock Paper Scissors")
-    .setDescription(`Choose your weapon!`)
-    .setColor(genColor(100));
-
   const reply = await interaction.reply({
-    embeds: [embed],
-    components: [row],
+    embeds: [baseEmbed],
+    components: [optionsRow],
   });
 
   const collector = reply.createMessageComponentCollector({
@@ -175,8 +162,8 @@ export async function run(interaction: ChatInputCommandInteraction) {
     await interaction.editReply({
       embeds: [
         new EmbedBuilder()
-          .setTitle("Game Timed Out")
-          .setDescription("The game has been cancelled due to inactivity.")
+          .setTitle("Game timed out")
+          .setDescription("The game was cancelled due to inactivity.")
           .setColor(genColor(0)),
       ],
       components: [],

--- a/src/commands/games/rps.ts
+++ b/src/commands/games/rps.ts
@@ -9,6 +9,7 @@ import {
 } from "discord.js";
 import { errorEmbed } from "../../utils/embeds/errorEmbed.ts";
 import { genColor } from "../../utils/colorGen.ts";
+import { randomize } from "../../utils/randomize.ts";
 
 type RPSChoice = "rock" | "paper" | "scissors";
 const rpsChoices: RPSChoice[] = ["rock", "paper", "scissors"];
@@ -150,7 +151,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
 
   collector.on("collect", async (i: ButtonInteraction) => {
     const playerChoice = i.customId.split("_")[1] as RPSChoice;
-    const botChoice = rpsChoices[Math.floor(Math.random() * rpsChoices.length)];
+    const botChoice = randomize(rpsChoices);
     const winner = getWinner(playerChoice, botChoice);
 
     const resultEmbed = new EmbedBuilder()

--- a/src/commands/games/rps.ts
+++ b/src/commands/games/rps.ts
@@ -8,6 +8,7 @@ import {
   type ChatInputCommandInteraction,
 } from "discord.js";
 import { errorEmbed } from "../../utils/embeds/errorEmbed.ts";
+import { genColor } from "../../utils/colorGen.ts";
 
 type RPSChoice = "rock" | "paper" | "scissors";
 const rpsChoices: RPSChoice[] = ["rock", "paper", "scissors"];
@@ -39,7 +40,15 @@ export async function run(interaction: ChatInputCommandInteraction) {
   const opponent = interaction.options.getUser("opponent");
   if (opponent) {
     if (opponent.bot)
-      return await errorEmbed(interaction, "Invalid opponent", "You cannot play against a bot!");
+      return await errorEmbed(
+        interaction,
+        "Invalid opponent",
+        `You cannot play against a bot!${
+          opponent.id === interaction.client.user.id
+            ? " To challenge Sokora itself, run `/games rps` without specifying the opponent."
+            : ""
+        }`,
+      );
 
     if (opponent.id == interaction.user.id)
       return await errorEmbed(interaction, "Invalid opponent", "You cannot play against yourself!");
@@ -59,7 +68,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
         `${interaction.user} has challenged ${opponent} to a game!\n` +
           `Both players, make your choice!`,
       )
-      .setColor("#00ff00");
+      .setColor(genColor(120));
 
     const reply = await interaction.reply({
       embeds: [embed],
@@ -85,7 +94,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
             new EmbedBuilder()
               .setTitle("Game Timed Out")
               .setDescription("The game has been cancelled due to inactivity.")
-              .setColor("#ff0000"),
+              .setColor(genColor(0)),
           ],
           components: [],
         });
@@ -104,7 +113,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
                 winner === 0 ? "It's a tie!" : winner === 1 ? interaction.user : opponent
               }`,
           )
-          .setColor(winner === 0 ? "#ffff00" : "#00ff00");
+          .setColor(winner === 0 ? genColor(60) : genColor(120));
 
         await interaction.editReply({
           embeds: [resultEmbed],
@@ -127,7 +136,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
   const embed = new EmbedBuilder()
     .setTitle("Rock Paper Scissors")
     .setDescription(`Choose your weapon!`)
-    .setColor("#00ff00");
+    .setColor(genColor(100));
 
   const reply = await interaction.reply({
     embeds: [embed],
@@ -151,7 +160,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
           `Bot: ${rpsEmojis[botChoice]}\n\n` +
           `Result: ${winner === 0 ? "It's a tie!" : winner === 1 ? "You win!" : "Bot wins!"}`,
       )
-      .setColor(winner === 0 ? "#ffff00" : winner === 1 ? "#00ff00" : "#ff0000");
+      .setColor(winner === 0 ? genColor(60) : winner === 1 ? genColor(120) : genColor(0));
 
     await i.update({
       embeds: [resultEmbed],
@@ -167,7 +176,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
         new EmbedBuilder()
           .setTitle("Game Timed Out")
           .setDescription("The game has been cancelled due to inactivity.")
-          .setColor("#ff0000"),
+          .setColor(genColor(0)),
       ],
       components: [],
     });

--- a/src/commands/moderation/clear.ts
+++ b/src/commands/moderation/clear.ts
@@ -4,7 +4,6 @@ import {
   type ChatInputCommandInteraction,
 } from "discord.js";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
-import { logChannel } from "../../utils/logChannel";
 import { pluralOrNot } from "../../utils/pluralOrNot";
 import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
 import { mention } from "../../utils/mention";
@@ -87,7 +86,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
     }
   }
 
-  const embed = modActionEmbed(
+  await modActionEmbed(
     `Cleared ${deletedAmount} ${pluralOrNot("message", deletedAmount)}.`,
     [
       `**Moderator**: ${interaction.user.displayName}`,
@@ -96,8 +95,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
     ]
       .filter(Boolean)
       .join("\n"),
+    guild,
+    interaction,
   );
-
-  await logChannel(guild, embed);
-  await interaction.reply({ embeds: [embed] });
 }

--- a/src/commands/moderation/clear.ts
+++ b/src/commands/moderation/clear.ts
@@ -1,13 +1,13 @@
 import {
   ChannelType,
-  EmbedBuilder,
   SlashCommandSubcommandBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";
-import { genColor } from "../../utils/colorGen";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { logChannel } from "../../utils/logChannel";
 import { pluralOrNot } from "../../utils/pluralOrNot";
+import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
+import { mention } from "../../utils/mention";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("clear")
@@ -87,18 +87,16 @@ export async function run(interaction: ChatInputCommandInteraction) {
     }
   }
 
-  const embed = new EmbedBuilder()
-    .setAuthor({ name: `Cleared ${deletedAmount} ${pluralOrNot("message", deletedAmount)}.` })
-    .setDescription(
-      [
-        `**Moderator**: ${interaction.user.displayName}`,
-        `**Channel**: ${channelOption ?? `<#${channel.id}>`}`,
-        targetUser ? `**Target User**: ${targetUser.displayName}` : null,
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    )
-    .setColor(genColor(100));
+  const embed = modActionEmbed(
+    `Cleared ${deletedAmount} ${pluralOrNot("message", deletedAmount)}.`,
+    [
+      `**Moderator**: ${interaction.user.displayName}`,
+      `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
+      targetUser ? `**Target User**: ${targetUser.displayName}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
 
   await logChannel(guild, embed);
   await interaction.reply({ embeds: [embed] });

--- a/src/commands/moderation/lock.ts
+++ b/src/commands/moderation/lock.ts
@@ -1,12 +1,12 @@
 import {
   ChannelType,
-  EmbedBuilder,
   SlashCommandSubcommandBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";
-import { genColor } from "../../utils/colorGen";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { logChannel } from "../../utils/logChannel";
+import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
+import { mention } from "../../utils/mention";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("lock")
@@ -41,15 +41,10 @@ export async function run(interaction: ChatInputCommandInteraction) {
       "The channel is already locked.",
     );
 
-  const embed = new EmbedBuilder()
-    .setAuthor({ name: `Locked a channel.` })
-    .setDescription(
-      [
-        `**Moderator**: ${interaction.user.displayName}`,
-        `**Channel**: ${channelOption ?? `<#${channel.id}>`}`,
-      ].join("\n"),
-    )
-    .setColor(genColor(100));
+  const embed = modActionEmbed("Locked a channel.", [
+    `**Moderator**: ${interaction.user.displayName}`,
+    `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
+  ]);
 
   if (
     channel.type == ChannelType.GuildText &&

--- a/src/commands/moderation/lock.ts
+++ b/src/commands/moderation/lock.ts
@@ -4,7 +4,6 @@ import {
   type ChatInputCommandInteraction,
 } from "discord.js";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
-import { logChannel } from "../../utils/logChannel";
 import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
 import { mention } from "../../utils/mention";
 
@@ -41,11 +40,6 @@ export async function run(interaction: ChatInputCommandInteraction) {
       "The channel is already locked.",
     );
 
-  const embed = modActionEmbed("Locked a channel.", [
-    `**Moderator**: ${interaction.user.displayName}`,
-    `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
-  ]);
-
   if (
     channel.type == ChannelType.GuildText &&
     ChannelType.PublicThread &&
@@ -61,6 +55,13 @@ export async function run(interaction: ChatInputCommandInteraction) {
       })
       .catch(error => console.error(error));
 
-  await logChannel(guild, embed);
-  await interaction.reply({ embeds: [embed] });
+  await modActionEmbed(
+    "Locked a channel.",
+    [
+      `**Moderator**: ${interaction.user.displayName}`,
+      `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
+    ],
+    guild,
+    interaction,
+  );
 }

--- a/src/commands/moderation/slowdown.ts
+++ b/src/commands/moderation/slowdown.ts
@@ -5,7 +5,6 @@ import {
 } from "discord.js";
 import ms from "ms";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
-import { logChannel } from "../../utils/logChannel";
 import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
 import { mention } from "../../utils/mention";
 
@@ -51,12 +50,6 @@ export async function run(interaction: ChatInputCommandInteraction) {
   })}.`;
   if (!ms(time)) title = `Removed the slowdown from ${channelOption ?? `${channel.name}`}.`;
 
-  const embed = modActionEmbed(title, [
-    `**Moderator**: ${interaction.user.displayName}`,
-    reason ? `**Reason**: ${reason}` : "*No reason provided*",
-    `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
-  ]);
-
   if (
     channel.type == ChannelType.GuildText &&
     ChannelType.PublicThread &&
@@ -67,6 +60,14 @@ export async function run(interaction: ChatInputCommandInteraction) {
       .setRateLimitPerUser(ms(time) / 1000, interaction.options.getString("reason")!)
       .catch(error => console.error(error));
 
-  await logChannel(guild, embed);
-  await interaction.reply({ embeds: [embed] });
+  await modActionEmbed(
+    title,
+    [
+      `**Moderator**: ${interaction.user.displayName}`,
+      reason ? `**Reason**: ${reason}` : "*No reason provided*",
+      `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
+    ],
+    guild,
+    interaction,
+  );
 }

--- a/src/commands/moderation/slowdown.ts
+++ b/src/commands/moderation/slowdown.ts
@@ -1,13 +1,13 @@
 import {
   ChannelType,
-  EmbedBuilder,
   SlashCommandSubcommandBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";
 import ms from "ms";
-import { genColor } from "../../utils/colorGen";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { logChannel } from "../../utils/logChannel";
+import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
+import { mention } from "../../utils/mention";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("slowdown")
@@ -51,16 +51,11 @@ export async function run(interaction: ChatInputCommandInteraction) {
   })}.`;
   if (!ms(time)) title = `Removed the slowdown from ${channelOption ?? `${channel.name}`}.`;
 
-  const embed = new EmbedBuilder()
-    .setAuthor({ name: title })
-    .setDescription(
-      [
-        `**Moderator**: ${interaction.user.displayName}`,
-        reason ? `**Reason**: ${reason}` : "*No reason provided*",
-        `**Channel**: ${channelOption ?? `<#${channel.id}>`}`,
-      ].join("\n"),
-    )
-    .setColor(genColor(100));
+  const embed = modActionEmbed(title, [
+    `**Moderator**: ${interaction.user.displayName}`,
+    reason ? `**Reason**: ${reason}` : "*No reason provided*",
+    `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
+  ]);
 
   if (
     channel.type == ChannelType.GuildText &&

--- a/src/commands/moderation/unlock.ts
+++ b/src/commands/moderation/unlock.ts
@@ -4,7 +4,6 @@ import {
   type ChatInputCommandInteraction,
 } from "discord.js";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
-import { logChannel } from "../../utils/logChannel";
 import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
 import { mention } from "../../utils/mention";
 
@@ -41,11 +40,6 @@ export async function run(interaction: ChatInputCommandInteraction) {
       "The channel is not locked.",
     );
 
-  const embed = modActionEmbed("Unlocked a channel.", [
-    `**Moderator**: ${interaction.user.displayName}`,
-    `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
-  ]);
-
   if (
     channel.type == ChannelType.GuildText &&
     ChannelType.PublicThread &&
@@ -61,6 +55,13 @@ export async function run(interaction: ChatInputCommandInteraction) {
       })
       .catch(error => console.error(error));
 
-  await logChannel(guild, embed);
-  await interaction.reply({ embeds: [embed] });
+  await modActionEmbed(
+    "Unlocked a channel.",
+    [
+      `**Moderator**: ${interaction.user.displayName}`,
+      `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
+    ],
+    guild,
+    interaction,
+  );
 }

--- a/src/commands/moderation/unlock.ts
+++ b/src/commands/moderation/unlock.ts
@@ -1,12 +1,12 @@
 import {
   ChannelType,
-  EmbedBuilder,
   SlashCommandSubcommandBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";
-import { genColor } from "../../utils/colorGen";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { logChannel } from "../../utils/logChannel";
+import { modActionEmbed } from "../../utils/embeds/modActionEmbed";
+import { mention } from "../../utils/mention";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("unlock")
@@ -41,15 +41,10 @@ export async function run(interaction: ChatInputCommandInteraction) {
       "The channel is not locked.",
     );
 
-  const embed = new EmbedBuilder()
-    .setAuthor({ name: `Unlocked a channel.` })
-    .setDescription(
-      [
-        `**Moderator**: ${interaction.user.displayName}`,
-        `**Channel**: ${channelOption ?? `<#${channel.id}>`}`,
-      ].join("\n"),
-    )
-    .setColor(genColor(100));
+  const embed = modActionEmbed("Unlocked a channel.", [
+    `**Moderator**: ${interaction.user.displayName}`,
+    `**Channel**: ${channelOption ?? mention(channel.id, "CHANNEL")}`,
+  ]);
 
   if (
     channel.type == ChannelType.GuildText &&

--- a/src/commands/news/edit.ts
+++ b/src/commands/news/edit.ts
@@ -14,6 +14,7 @@ import { get, updateNews } from "../../utils/database/news";
 import { getSetting } from "../../utils/database/settings";
 import { errorEmbed } from "../../utils/embeds/errorEmbed";
 import { sendChannelNews } from "../../utils/sendChannelNews";
+import { mention } from "../../utils/mention";
 
 export const data = new SlashCommandSubcommandBuilder()
   .setName("edit")
@@ -87,7 +88,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
       ) as TextChannel
     )?.messages.edit(news.messageID, {
       embeds: [embed],
-      content: roleToSend ? `<@&${roleToSend.id}>` : undefined,
+      content: roleToSend ? mention(roleToSend.id, "ROLE") : undefined,
     });
 
     updateNews(guild.id, id, title, body);

--- a/src/commands/serverboard.ts
+++ b/src/commands/serverboard.ts
@@ -7,7 +7,7 @@ import {
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";
-import { listPublicServers } from "../utils/database/settings";
+import { deletePublicServer, listPublicServers } from "../utils/database/settings";
 import { errorEmbed } from "../utils/embeds/errorEmbed";
 import { serverEmbed } from "../utils/embeds/serverEmbed";
 
@@ -27,9 +27,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
             inviteChannelId: entry.inviteChannelId,
           };
         } catch {
-          // skip entry (we'll get into here most likely because of sokora not being inside of a listable server)
-          // most likely a server kicking sokora without disabling serverboard
-          // TODO - remove the server ID from the list too
+          deletePublicServer(entry.guildID);
           return null;
         }
       }),

--- a/src/commands/serverboard.ts
+++ b/src/commands/serverboard.ts
@@ -4,7 +4,6 @@ import {
   ButtonInteraction,
   ButtonStyle,
   Guild,
-  GuildManager,
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -18,6 +18,7 @@ import {
 import { errorEmbed } from "../utils/embeds/errorEmbed";
 import { capitalize } from "../utils/capitalize";
 import { humanizeSettings } from "../utils/humanizeSettings";
+import { mention } from "../utils/mention";
 
 export let data = new SlashCommandBuilder()
   .setName("settings")
@@ -159,13 +160,13 @@ export async function run(interaction: ChatInputCommandInteraction) {
     let text;
     switch (settingsDef.settings[name].type) {
       case "CHANNEL":
-        text = setting ? `<#${setting}>` : "Not set";
+        text = setting ? mention(setting, "CHANNEL") : "*Not set*";
         break;
       case "USER":
-        text = setting ? `<@${setting}>` : "Not set";
+        text = setting ? mention(setting, "USER") : "*Not set*";
         break;
       case "ROLE":
-        text = setting ? `<@&${setting}>` : "Not set";
+        text = setting ? mention(setting, "ROLE") : "*Not set*";
         break;
       default:
         text = setting || "*Not set*";

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -13,6 +13,7 @@ import { getSetting } from "../utils/database/settings";
 import { errorEmbed } from "../utils/embeds/errorEmbed";
 import { imageColor } from "../utils/imageColor";
 import { pluralOrNot } from "../utils/pluralOrNot";
+import { mention } from "../utils/mention";
 
 export const data = new SlashCommandBuilder()
   .setName("user")
@@ -67,7 +68,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
         memberRoles.length,
       )} • ${memberRoles
         .slice(0, 3)
-        .map(role => `<@&${role[1].id}>`)
+        .map(role => mention(role[1].id, "ROLE"))
         .join(", ")}${rolesLength > 3 ? ` and **${rolesLength - 3}** more` : ""}`,
     );
 

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -11,6 +11,7 @@ import { kominator } from "../utils/kominator";
 import { leavePlease } from "../utils/leavePlease";
 import { logChannel } from "../utils/logChannel.ts";
 import { Event } from "../utils/types";
+import { mention } from "../utils/mention.ts";
 
 const cooldowns = new Map<string, number>();
 export default (async function run(message) {
@@ -170,6 +171,6 @@ export default (async function run(message) {
   if (levelChannelId)
     (guild.channels.cache.get(`${levelChannelId}`) as TextChannel).send({
       embeds: [embed],
-      content: `<@${author.id}>`,
+      content: mention(author.id, "USER"),
     });
 } as Event<"messageCreate">);

--- a/src/utils/database/settings.ts
+++ b/src/utils/database/settings.ts
@@ -330,6 +330,9 @@ const getQuery = database.query("SELECT * FROM settings WHERE guildID = $1 AND k
 const listPublicQuery = database.query(
   "SELECT * FROM settings WHERE key = 'serverboard.shown' AND value = '1';",
 );
+const deletePublicQuery = database.query(
+  "DELETE FROM settings WHERE guildID = $1 AND key = 'serverboard.shown' AND value = '1'",
+);
 const listPublicWithInvitesEnabledQuery = database.query(
   "SELECT * FROM settings WHERE EXISTS (SELECT 1 FROM settings WHERE key = 'serverboard.server_invite' AND value = '1') AND EXISTS (SELECT 1 FROM settings WHERE key = 'serverboard.shown' AND value = '1');",
 );
@@ -415,4 +418,12 @@ export function listPublicServers(): {
       inviteChannelId: inviteChannel ? inviteChannel.toString() : null,
     };
   });
+}
+
+export function deletePublicServer(guildId: string) {
+  try {
+    deletePublicQuery.all(JSON.stringify(guildId));
+  } catch (e) {
+    console.error(e);
+  }
 }

--- a/src/utils/embeds/modActionEmbed.ts
+++ b/src/utils/embeds/modActionEmbed.ts
@@ -1,16 +1,32 @@
-import { EmbedBuilder } from "discord.js";
+import { ChatInputCommandInteraction, EmbedBuilder, Guild } from "discord.js";
 import { genColor } from "../colorGen";
+import { logChannel } from "../logChannel";
 
 /**
- * Creates an embed for a moderator's action. Does _not_ send it.
+ * Creates an embed for a moderator's action and replies to the given interaction with it.
  *
+ * @async
  * @param {string} title Title of the embed (set as `author.name`).
  * @param {(string | string[])} body Description of the embed.
+ * @param {Guild} guild Guild to `logChannel()` to.
+ * @param {ChatInputCommandInteraction} i Interaction to reply to.
  * @returns {EmbedBuilder} An `EmbedBuilder` you can build on top of.
  */
-export function modActionEmbed(title: string, body: string | string[]): EmbedBuilder {
-  return new EmbedBuilder()
-    .setAuthor({ name: title })
-    .setDescription(Array.isArray(body) ? body.join("\n") : body)
-    .setColor(genColor(100));
+export async function modActionEmbed(
+  title: string,
+  body: string | string[],
+  guild: Guild,
+  i: ChatInputCommandInteraction,
+): Promise<void> {
+  try {
+    const embed = new EmbedBuilder()
+      .setAuthor({ name: title })
+      .setDescription(Array.isArray(body) ? body.join("\n") : body)
+      .setColor(genColor(100));
+
+    await logChannel(guild, embed);
+    await i.reply({ embeds: [embed] });
+  } catch (e) {
+    console.error(e);
+  }
 }

--- a/src/utils/embeds/modActionEmbed.ts
+++ b/src/utils/embeds/modActionEmbed.ts
@@ -1,0 +1,16 @@
+import { EmbedBuilder } from "discord.js";
+import { genColor } from "../colorGen";
+
+/**
+ * Creates an embed for a moderator's action. Does _not_ send it.
+ *
+ * @param {string} title Title of the embed (set as `author.name`).
+ * @param {(string | string[])} body Description of the embed.
+ * @returns {EmbedBuilder} An `EmbedBuilder` you can build on top of.
+ */
+export function modActionEmbed(title: string, body: string | string[]): EmbedBuilder {
+  return new EmbedBuilder()
+    .setAuthor({ name: title })
+    .setDescription(Array.isArray(body) ? body.join("\n") : body)
+    .setColor(genColor(100));
+}

--- a/src/utils/embeds/serverEmbed.ts
+++ b/src/utils/embeds/serverEmbed.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder, Invite, type Guild } from "discord.js";
 import { genColor } from "../colorGen";
 import { imageColor } from "../imageColor";
 import { pluralOrNot } from "../pluralOrNot";
+import { SOKORA_ID } from "../../bot";
 
 type Options = {
   guild: Guild;
@@ -127,7 +128,7 @@ export async function serverEmbed(options: Options) {
   if (options.invite?.show) {
     const previousInvite: Invite | undefined = (await options.guild.invites.fetch()).find(
       invite =>
-        invite.inviter?.id == "873918300726394960" &&
+        invite.inviter?.id == SOKORA_ID &&
         invite.maxUses == null &&
         invite.expiresAt == null,
     );

--- a/src/utils/embeds/serverEmbed.ts
+++ b/src/utils/embeds/serverEmbed.ts
@@ -2,7 +2,6 @@ import { EmbedBuilder, Invite, type Guild } from "discord.js";
 import { genColor } from "../colorGen";
 import { imageColor } from "../imageColor";
 import { pluralOrNot } from "../pluralOrNot";
-import { SOKORA_ID } from "../../bot";
 
 type Options = {
   guild: Guild;
@@ -128,7 +127,7 @@ export async function serverEmbed(options: Options) {
   if (options.invite?.show) {
     const previousInvite: Invite | undefined = (await options.guild.invites.fetch()).find(
       invite =>
-        invite.inviter?.id == SOKORA_ID &&
+        invite.inviter?.id == guild.client.user.id &&
         invite.maxUses == null &&
         invite.expiresAt == null,
     );

--- a/src/utils/embeds/serverEmbed.ts
+++ b/src/utils/embeds/serverEmbed.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder, Invite, type Guild } from "discord.js";
 import { genColor } from "../colorGen";
 import { imageColor } from "../imageColor";
 import { pluralOrNot } from "../pluralOrNot";
+import { mention } from "../mention";
 
 type Options = {
   guild: Guild;
@@ -79,7 +80,7 @@ export async function serverEmbed(options: Options) {
         value: safetyValues.join(" • "),
       },
     )
-    .setFooter({ text: `${pages ? `Page ${page}/${pages}\n` : ""}Server ID: ${guild.id}` })
+    .setFooter({ text: `${pages ? `Page ${page}/${pages} • ` : ""}Server ID: ${guild.id}` })
     .setThumbnail(icon)
     .setColor((await imageColor(icon)) ?? genColor(200));
 
@@ -91,7 +92,7 @@ export async function serverEmbed(options: Options) {
           ? "*None*"
           : `${sortedRoles
               .slice(0, 5)
-              .map(role => `<@&${role[0]}>`)
+              .map(role => mention(role[0], "ROLE"))
               .join(" • ")}${rolesLength > 5 ? ` and **${rolesLength - 5}** more` : ""}`,
     });
 

--- a/src/utils/mention.ts
+++ b/src/utils/mention.ts
@@ -1,0 +1,49 @@
+/**
+ * Handles role mentions, channel mentions, timestamps, and more.
+ *
+ * @param {string | number} who Who to mention? If it's a timestamp, pass `Date.now()`.
+ * @param {(| "USER"
+ *     | "ROLE"
+ *     | "CHANNEL"
+ *     | "DEFAULT_TIMESTAMP"
+ *     | "SIMPLE_TIMESTAMP"
+ *     | "DETAILED_TIMESTAMP")} type What to mention?
+ * @returns {string} A `<@MENTION>` string.
+ */
+export function mention(
+  who: string | number,
+  type:
+    | "USER"
+    | "ROLE"
+    | "CHANNEL"
+    | "DEFAULT_TIMESTAMP"
+    | "SIMPLE_TIMESTAMP"
+    | "DETAILED_TIMESTAMP",
+): string {
+  switch (type) {
+    case "CHANNEL":
+      return `<#${who}>`;
+    case "USER":
+      return `<@${who}>`;
+    case "ROLE":
+      return `<@&${who}>`;
+    case "DEFAULT_TIMESTAMP":
+    case "DETAILED_TIMESTAMP":
+    case "SIMPLE_TIMESTAMP": {
+      if (typeof who !== "number" || isNaN(Number(who))) {
+        console.error(
+          "Asked to format a timestamp but provided a string. You should provide timestamps as a number by using Date.now() (without flooring whatsoever). You were given back the string untouched.",
+        );
+        return who.toString();
+      }
+      switch (type) {
+        case "DEFAULT_TIMESTAMP":
+          return `<t:${Math.floor(who / 1000)}:D>`;
+        case "SIMPLE_TIMESTAMP":
+          return `<t:${Math.floor(who / 1000)}:d>`;
+        case "DETAILED_TIMESTAMP":
+          return `<t:${Math.floor(who / 1000)}>`;
+      }
+    }
+  }
+}

--- a/src/utils/randomize.ts
+++ b/src/utils/randomize.ts
@@ -1,9 +1,8 @@
 /**
  * Randomizes array values.
- * @param array Array to randomize.
- * @returns Randomized value from within the array.
+ * @param {T[]} array Array to randomize.
+ * @returns {T} Randomized value from within the array.
  */
-
-export function randomize(array: any[]) {
+export function randomize<T>(array: T[]): T {
   return array[Math.floor(Math.random() * array.length)];
 }

--- a/src/utils/replace.ts
+++ b/src/utils/replace.ts
@@ -1,6 +1,7 @@
 import { Guild, User } from "discord.js";
 import { randomize } from "./randomize";
 import { Replacements } from "./types";
+import { mention } from "./mention";
 
 let emojis = ["💖", "💝", "💓", "💗", "💘", "💟", "💕", "💞"];
 if (Math.round(Math.random() * 100) <= 5) emojis = ["⌨️", "💻", "🖥️"];
@@ -32,9 +33,9 @@ export async function replaceVariables(text: string, guild: Guild, user: User): 
     { text: "(count)", replacement: guild.memberCount },
     { text: "(servername)", replacement: guild.name },
     { text: "(serverowner)", replacement: (await guild.fetchOwner()).displayName },
-    { text: "(currentdate)", replacement: `<t:${Math.floor(Date.now() / 1000)}:D>` },
-    { text: "(currentdate, simple)", replacement: `<t:${Math.floor(Date.now() / 1000)}:d>` },
-    { text: "(currentdate, detailed)", replacement: `<t:${Math.floor(Date.now() / 1000)}>` },
+    { text: "(currentdate)", replacement: mention(Date.now(), "DEFAULT_TIMESTAMP") },
+    { text: "(currentdate, simple)", replacement: mention(Date.now(), "SIMPLE_TIMESTAMP") },
+    { text: "(currentdate, detailed)", replacement: mention(Date.now(), "DETAILED_TIMESTAMP") },
   ];
 
   return replace(text, replacementVariables);

--- a/src/utils/sendChannelNews.ts
+++ b/src/utils/sendChannelNews.ts
@@ -18,6 +18,7 @@ import {
 import { genColor } from "./colorGen";
 import { get, updateNews } from "./database/news";
 import { getSetting } from "./database/settings";
+import { mention } from "./mention";
 
 export async function sendChannelNews(
   guild: Guild,
@@ -48,7 +49,7 @@ export async function sendChannelNews(
   return await channel
     .send({
       embeds: [embed],
-      content: roleToSend ? `<@&${roleToSend.id}>` : undefined,
+      content: roleToSend ? mention(roleToSend.id, "ROLE") : undefined,
     })
     .then(message => updateNews(guild.id, id, undefined, undefined, message.id));
 }


### PR DESCRIPTION
this PR does
- what the title says (public server fix)
- fixes a minor issue that caused the link to CONTRIBUTING.md in README file not work
- makes Sokora's ID not hardcoded
- makes RPS colors not hardcoded (genColor)
- improve RPS source code
- better type `randomize()` (now `randomize<T>()`)
- add `mention(string, "ROLE" | "CHANNEL" | etc...)` so you don't have to remember how to mention roles, channels, users, or _timestamps_
  - there are three timestamp options, being the three options we offer via `dynamic (variables)`, and you have to pass `Date.now()` as the string for it to work (it manages `Math.floor()` for ya)
- add `modActionEmbed()` for mod action's code to be shorter